### PR TITLE
fix #27

### DIFF
--- a/Editor/ShaderInfo/TextureBaker.cs
+++ b/Editor/ShaderInfo/TextureBaker.cs
@@ -77,7 +77,7 @@ namespace io.github.azukimochi
             var source = Texture;
             if (source != null)
             {
-                (width, height) = (source.width, source.height);
+                (width, height) = (Mathf.Max(32, source.width), Mathf.Max(32, source.height));
             }
 
             var dest = new Texture2D(width, height, TextureFormat.RGBA32, false);


### PR DESCRIPTION
１ピクセルしかないとテクスチャの読み込みに失敗するので、縦横の最低ピクセル数を32にすることで回避・・・