### PR TITLE
テクスチャ焼き込みの修正

### DIFF
--- a/Editor/ShaderInfo/TextureBaker.cs
+++ b/Editor/ShaderInfo/TextureBaker.cs
@@ -89,7 +89,7 @@ namespace io.github.azukimochi
                 (width, height) = (Mathf.Max(32, source.width), Mathf.Max(32, source.height));
             }
 
-            var dest = new Texture2D(width, height, TextureFormat.RGBA32, false);
+            var dest = new Texture2D(width, height, TextureFormat.RGBA32, true);
             var rt = RenderTexture.GetTemporary(width, height);
             var temp = RenderTexture.active;
             try
@@ -98,8 +98,8 @@ namespace io.github.azukimochi
 
                 var request = AsyncGPUReadback.Request(rt);
                 request.WaitForCompletion();
-                dest.LoadRawTextureData(request.GetData<Color>());
-                dest.Apply();
+                dest.SetPixelData(request.GetData<Color>(), 0);
+                dest.Apply(true);
 
                 var format = (source as Texture2D)?.format ?? (Color.a == 1 ? TextureFormat.DXT1Crunched : TextureFormat.DXT5);
                 int quality = (AssetImporter.GetAtPath(AssetDatabase.GetAssetPath(source)) as TextureImporter)?.compressionQuality ?? 50;

--- a/Editor/ShaderInfo/TextureBaker.shader
+++ b/Editor/ShaderInfo/TextureBaker.shader
@@ -5,7 +5,7 @@
         [NoScaleOffset][MainTexture] _MainTex ("Texture", 2D) = "white" {}
         [NoScaleOffset] _Mask ("Mask", 2D) = "white" {}
         [NoScaleOffset] _GradationMap("Gradation", 2D) = "white" {}
-        [HDR][MainColor] _Color ("Color", Color) = (1, 1, 1, 1)
+        [MainColor] _Color ("Color", Color) = (1, 1, 1, 1)
         _HSVG ("HSVG", Vector) = (0,1,1,1)
         _GradationStrength("Gradation Strength", Range(0, 1)) = 0
     }


### PR DESCRIPTION
#78 の修正です。
色がおかしくなるのはHDRの処理を間違えていたっぽいです（よくわからなかった）
ついでにミップマップが正常に働くようにも。