### PR TITLE
fix: skip cloning AudioClip, which is used by VRCAnimatorPlayAudio StateMachineBehaviour

### DIFF
--- a/Editor/ObjectMapping/AnimatorControllerMapper.cs
+++ b/Editor/ObjectMapping/AnimatorControllerMapper.cs
@@ -133,6 +133,8 @@ namespace Anatawa12.AvatarOptimizer
                 case StateMachineBehaviour _:
                     break; // We want to clone these types
 
+                case AudioClip _: // Used in VRC Animator Play Audio State Behavior
+
                 case AvatarMask _:
                     return original;
 


### PR DESCRIPTION
see bdunderscore/modular-avatar#780