### PR TITLE
fix: wrong color baking texture on Apple Silicon

### DIFF
--- a/Editor/ShaderInfo/TextureBaker.cs
+++ b/Editor/ShaderInfo/TextureBaker.cs
@@ -96,7 +96,7 @@ namespace io.github.azukimochi
             {
                 Graphics.Blit(source, rt, Material);
 
-                var request = AsyncGPUReadback.Request(rt);
+                var request = AsyncGPUReadback.Request(rt, 0, TextureFormat.RGBA32);
                 request.WaitForCompletion();
                 dest.SetPixelData(request.GetData<Color>(), 0);
                 dest.Apply(true);


### PR DESCRIPTION
AsyncGPUReadback is used to read the baked texture from the GPU, but on Apple Silicon this causes colors to look wrong

Fix this by explicitly setting dstFormat to match the destination Texture2D's format TextureFormat.RGBA32 so that automatic conversion happens

Fixes #151