### PR TITLE
Register ReplacedObject again

### DIFF
--- a/Editor/NDMF/Passes.CloningMaterialsPass.cs
+++ b/Editor/NDMF/Passes.CloningMaterialsPass.cs
@@ -108,6 +108,7 @@ namespace io.github.azukimochi
                     if (ShaderInfo.TryGetShaderInfo(material, out var info) && Session.Parameters.TargetShaders.Contains(info.Name))
                     {
                         clonedMaterial = material.Clone();
+                        ObjectRegistry.RegisterReplacedObject(material, clonedMaterial);
                         Cache.Register(material, clonedMaterial);
                         return true;
                     }

--- a/Editor/ObjectMapping/AnimatorControllerMapper.cs
+++ b/Editor/ObjectMapping/AnimatorControllerMapper.cs
@@ -75,6 +75,7 @@ namespace Anatawa12.AvatarOptimizer
                 newClip.frameRate = clip.frameRate;
                 newClip.localBounds = clip.localBounds;
                 AnimationUtility.SetAnimationClipSettings(newClip, AnimationUtility.GetAnimationClipSettings(clip));
+                ObjectRegistry.RegisterReplacedObject(clip, newClip);
                 return newClip;
             }
             else if (o is RuntimeAnimatorController controller)
@@ -193,6 +194,7 @@ namespace Anatawa12.AvatarOptimizer
                 so.ApplyModifiedPropertiesWithoutUndo();
             }
 
+            ObjectRegistry.RegisterReplacedObject(original, obj);
             return (T)obj;
         }
 

--- a/Editor/ObjectMapping/AnimatorControllerMapper.cs
+++ b/Editor/ObjectMapping/AnimatorControllerMapper.cs
@@ -37,6 +37,7 @@ namespace Anatawa12.AvatarOptimizer
             if (o is AnimationClip clip)
             {
                 var newClip = new AnimationClip();
+                ObjectRegistry.RegisterReplacedObject(clip, newClip);
                 newClip.name = "remapped " + clip.name;
 
                 // copy m_UseHighQualityCurve with SerializedObject since m_UseHighQualityCurve doesn't have public API
@@ -75,7 +76,6 @@ namespace Anatawa12.AvatarOptimizer
                 newClip.frameRate = clip.frameRate;
                 newClip.localBounds = clip.localBounds;
                 AnimationUtility.SetAnimationClipSettings(newClip, AnimationUtility.GetAnimationClipSettings(clip));
-                ObjectRegistry.RegisterReplacedObject(clip, newClip);
                 return newClip;
             }
             else if (o is RuntimeAnimatorController controller)
@@ -182,6 +182,7 @@ namespace Anatawa12.AvatarOptimizer
                 obj = (T)ctor.Invoke(Array.Empty<object>());
                 EditorUtility.CopySerialized(original, obj);
             }
+            ObjectRegistry.RegisterReplacedObject(original, obj);
 
             _cache[original] = obj;
             _cache[obj] = obj;
@@ -194,7 +195,6 @@ namespace Anatawa12.AvatarOptimizer
                 so.ApplyModifiedPropertiesWithoutUndo();
             }
 
-            ObjectRegistry.RegisterReplacedObject(original, obj);
             return (T)obj;
         }
 

--- a/Editor/ShaderInfo/ShaderInfo.LilToon.cs
+++ b/Editor/ShaderInfo/ShaderInfo.LilToon.cs
@@ -120,6 +120,8 @@ namespace io.github.azukimochi
                 if (bakeFlag)
                 {
                     var baked = cache.Register(textureBaker.Bake());
+                    if (tex != null)
+                        ObjectRegistry.RegisterReplacedObject(tex, baked);
                     material.SetTexture(PropertyIDs.MainTex, baked);
                 }
 
@@ -151,6 +153,8 @@ namespace io.github.azukimochi
                 if (bakeFlag)
                 {
                     var baked = cache.Register(textureBaker.Bake());
+                    if (tex != null)
+                        ObjectRegistry.RegisterReplacedObject(tex, baked);
                     material.SetTexture(propertyIds.Texture, baked);
                 }
 

--- a/Editor/ShaderInfo/ShaderInfo.LilToon.cs
+++ b/Editor/ShaderInfo/ShaderInfo.LilToon.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using nadena.dev.ndmf;
 using UnityEngine;
 
 namespace io.github.azukimochi
@@ -120,8 +119,6 @@ namespace io.github.azukimochi
                 if (bakeFlag)
                 {
                     var baked = cache.Register(textureBaker.Bake());
-                    if (tex != null)
-                        ObjectRegistry.RegisterReplacedObject(tex, baked);
                     material.SetTexture(PropertyIDs.MainTex, baked);
                 }
 
@@ -153,8 +150,6 @@ namespace io.github.azukimochi
                 if (bakeFlag)
                 {
                     var baked = cache.Register(textureBaker.Bake());
-                    if (tex != null)
-                        ObjectRegistry.RegisterReplacedObject(tex, baked);
                     material.SetTexture(propertyIds.Texture, baked);
                 }
 

--- a/Editor/ShaderInfo/ShaderInfo.Poiyomi.cs
+++ b/Editor/ShaderInfo/ShaderInfo.Poiyomi.cs
@@ -80,6 +80,8 @@ namespace io.github.azukimochi
                         if (bakeFlag)
                         {
                             var baked = cache.Register(textureBaker.Bake());
+                            if (tex != null)
+                                ObjectRegistry.RegisterReplacedObject(tex, baked);
                             material.TrySet(PropertyIDs.MainTex, baked);
                         }
 
@@ -109,6 +111,8 @@ namespace io.github.azukimochi
                         if (bakeFlag)
                         {
                             var baked = cache.Register(textureBaker.Bake());
+                            if (tex != null)
+                                ObjectRegistry.RegisterReplacedObject(tex, baked);
                             material.TrySet(PropertyIDs.DissolveToTexture, baked);
                         }
 

--- a/Editor/ShaderInfo/ShaderInfo.Poiyomi.cs
+++ b/Editor/ShaderInfo/ShaderInfo.Poiyomi.cs
@@ -80,8 +80,6 @@ namespace io.github.azukimochi
                         if (bakeFlag)
                         {
                             var baked = cache.Register(textureBaker.Bake());
-                            if (tex != null)
-                                ObjectRegistry.RegisterReplacedObject(tex, baked);
                             material.TrySet(PropertyIDs.MainTex, baked);
                         }
 
@@ -111,8 +109,6 @@ namespace io.github.azukimochi
                         if (bakeFlag)
                         {
                             var baked = cache.Register(textureBaker.Bake());
-                            if (tex != null)
-                                ObjectRegistry.RegisterReplacedObject(tex, baked);
                             material.TrySet(PropertyIDs.DissolveToTexture, baked);
                         }
 

--- a/Editor/ShaderInfo/ShaderInfo.Sunao.cs
+++ b/Editor/ShaderInfo/ShaderInfo.Sunao.cs
@@ -65,6 +65,8 @@ namespace io.github.azukimochi
                     if (bakeFlag)
                     {
                         var baked = cache.Register(textureBaker.Bake());
+                        if (tex != null)
+                            ObjectRegistry.RegisterReplacedObject(tex, baked);
                         material.SetTexture(PropertyIDs.MainTex, baked);
                     }
 

--- a/Editor/ShaderInfo/ShaderInfo.Sunao.cs
+++ b/Editor/ShaderInfo/ShaderInfo.Sunao.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using nadena.dev.ndmf;
 using UnityEngine;
 
 namespace io.github.azukimochi
@@ -65,8 +64,6 @@ namespace io.github.azukimochi
                     if (bakeFlag)
                     {
                         var baked = cache.Register(textureBaker.Bake());
-                        if (tex != null)
-                            ObjectRegistry.RegisterReplacedObject(tex, baked);
                         material.SetTexture(PropertyIDs.MainTex, baked);
                     }
 

--- a/Editor/ShaderInfo/TextureBaker.cs
+++ b/Editor/ShaderInfo/TextureBaker.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using nadena.dev.ndmf;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -89,6 +90,8 @@ namespace io.github.azukimochi
             }
 
             var dest = new Texture2D(width, height, TextureFormat.RGBA32, true);
+            if (source != null)
+                ObjectRegistry.RegisterReplacedObject(source, dest);
             dest.name = source?.name ?? Color.ToString();
             var rt = RenderTexture.GetTemporary(width, height);
             var temp = RenderTexture.active;


### PR DESCRIPTION
This PR reverts #168.

元のコードで発生していたエラーは`LightLimitChangerObjectCache`によって新規生成しなかった場合にも`ObjectRegistry.RegisterReplacedObject` を呼び出したことが原因だと考えられたたため、`new Texture2D`直後に移動することでこれを抑制しました。

また、他の場所においても`ObjectRegistry.RegisterReplacedObject`は生成されたあとに`ObjectRegistry.GetReference`が意図しない形であっても呼び出されてはいけないため、`ObjectRegistry.RegisterReplacedObject`を`Instantiate`直後に移動することで意図しない`ObjectRegistry.GetReference`の呼び出しを抑制します。

動作確認はまだ細かくやってないです