### PR TITLE
「初期の上限と下限を上書きする」にチェックをしている時に、セットする値が、そのままでは予期しない値が入るパターンがあり、DefaultLi…

### DIFF
--- a/Editor/NDMF/Passes.GenerateAnimationsPass.cs
+++ b/Editor/NDMF/Passes.GenerateAnimationsPass.cs
@@ -49,8 +49,9 @@ namespace io.github.azukimochi
                         }
                         else
                         {
-                            defaultMinLight = parameters.MinLightValue;
-                            defaultMaxLight = parameters.MaxLightValue;
+                            // Fix for defaultMinLight and defaultMaxLight.
+                            defaultMinLight = parameters.MinLightValue * parameters.DefaultMinLightValue;
+                            defaultMaxLight = parameters.MaxLightValue * parameters.DefaultMaxLightValue;
                         }
 
                         var param = new ControlAnimationParameters(relativePath, type, min, max, defaultMinLight, defaultMaxLight);


### PR DESCRIPTION
「初期の上限と下限を上書きする」にチェックをしている時に、セットする値が、そのままでは予期しない値が入るパターンがあり、DefaultLightValueをかけ合わせるように変更

実際に動作テストをして、意図通りの挙動になっていると思われるので、プルリクエストを発行します。

※以下、改修時に作成したパラメーターの意味についてのメモです。
`
// 明るさの初期値(0～1)
[Range(0, 1)]
public float DefaultLightValue = 0.5f;

// 明るさの下限の初期値(0～1)
[Range(0, 1)]
public float DefaultMinLightValue = 0.0f;

// 明るさの上限の初期値(0～1)
[Range(0, 1)]
public float DefaultMaxLightValue = 1.0f;

// 明るさの上限(0～10)
[Range(0, 10)]
public float MaxLightValue = 1.0f;

// 明るさの下限(0～10)
[Range(0, 10)]
public float MinLightValue = 0.0f;
`