### PR TITLE
feat: Add skip option for other editor extensions (currently only supported for liltoon)

### DIFF
--- a/Editor/ControlAnimationParameters.cs
+++ b/Editor/ControlAnimationParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 
 namespace io.github.azukimochi
 {
@@ -13,8 +14,9 @@ namespace io.github.azukimochi
         public readonly float DefaultMaxLightValue;
         public readonly float DefaultMonochromeLightingValue;
         public readonly float DefaultMonochromeAdditiveLightingValue;
+        public readonly Material[] Materials;
 
-        public ControlAnimationParameters(string targetPath, Type targetType, float minLightValue, float maxLightValue, float defaultMinLightValue, float defaultMaxLightValue, float defaultMonochromeLightingValue, float defaultMonochromeAdditiveLightingValue)
+        public ControlAnimationParameters(string targetPath, Type targetType, float minLightValue, float maxLightValue, float defaultMinLightValue, float defaultMaxLightValue, float defaultMonochromeLightingValue, float defaultMonochromeAdditiveLightingValue, Material[] materials)
         {
             TargetPath = targetPath;
             TargetType = targetType;
@@ -24,6 +26,7 @@ namespace io.github.azukimochi
             DefaultMaxLightValue = defaultMaxLightValue;
             DefaultMonochromeLightingValue = defaultMonochromeLightingValue;
             DefaultMonochromeAdditiveLightingValue = defaultMonochromeAdditiveLightingValue;
+            Materials = materials;
         }
     }
 }

--- a/Editor/NDMF/Passes.GenerateAnimationsPass.cs
+++ b/Editor/NDMF/Passes.GenerateAnimationsPass.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using gomoru.su;
 using nadena.dev.modular_avatar.core;
 using nadena.dev.ndmf;
@@ -29,6 +30,9 @@ namespace io.github.azukimochi
 
                     var relativePath = renderer.AvatarRootPath();
                     var type = renderer.GetType();
+                    var materials = renderer.sharedMaterials;
+                    if (materials == null)
+                        materials = Array.Empty<Material>();
 
                     foreach (var x in ShaderInfo.RegisteredShaderInfos)
                     {
@@ -67,7 +71,7 @@ namespace io.github.azukimochi
                             }
                         }
 
-                        var param = new ControlAnimationParameters(relativePath, type, min, max, defaultMinLight, defaultMaxLight, defaultMonochromeLighting, defaultMonochromeAdditiveLighting);
+                        var param = new ControlAnimationParameters(relativePath, type, min, max, defaultMinLight, defaultMaxLight, defaultMonochromeLighting, defaultMonochromeAdditiveLighting, materials);
                         foreach (ref readonly var container in animationContainers)
                         {
                             x.SetControlAnimation(container, param);


### PR DESCRIPTION
マテリアルにタグを設定することで一部処理を抑制できるように
例:
```cs
material.SetOverrideTag("LLC_TEXTUREBAKE_SKIP_OPTIONS", "lilMainTex;lil2ndTex");
material.SetOverrideTag("LLC_ANIMATION_SKIP_OPTIONS", "lilColorTemp2ndTex");
```